### PR TITLE
✨ : 一覧カードのコンポーネント化とPageView化

### DIFF
--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/provider/map_controller_completer_provider.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/provider/map_controller_completer_provider.dart
@@ -1,0 +1,8 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+/// GoogleMapControllerの非同期処理用プロバイダー
+final mapControllerCompleterProvider =
+    Provider<Completer<GoogleMapController>>((ref) => Completer());

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/charger_spots_screen.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/charger_spots_screen.dart
@@ -19,7 +19,6 @@ class ChargerSpotScreen extends ConsumerStatefulWidget {
 }
 
 class ChargerSpotScreenState extends ConsumerState<ChargerSpotScreen> {
-  final Completer<GoogleMapController> controller = Completer();
   final Duration showCardDuration = const Duration(milliseconds: 400);
   Position? position;
   // カードをせり出すかどうか
@@ -31,21 +30,18 @@ class ChargerSpotScreenState extends ConsumerState<ChargerSpotScreen> {
     return Scaffold(
       body: Stack(
         children: [
-          ChargerMap(
-            onTap: _onMapTap,
-            position: position,
-            controller: controller,
+          GestureDetector(
+            onTapDown: (_) => _onMapTapDown(),
+            child: const ChargerMap(),
           ),
           AnimatedPositioned(
             duration: showCardDuration,
             bottom: showCard ? 320.0 : 150.0,
             right: 16.0,
-            child: SizedBox(
+            child: const SizedBox(
               width: 62.0,
               height: 62.0,
-              child: CurrentLocationButton(
-                controller: controller,
-              ),
+              child: CurrentLocationButton(),
             ),
           ),
           AnimatedPositioned(
@@ -56,12 +52,7 @@ class ChargerSpotScreenState extends ConsumerState<ChargerSpotScreen> {
             child: SizedBox(
               height: 272.0,
               child: GestureDetector(
-                onTapDown: (_) {
-                  if (showCard) return;
-                  setState(() {
-                    showCard = true;
-                  });
-                },
+                onTapDown: (_) => _onCardTapDown(),
                 child: const CardList(),
               ),
             ),
@@ -71,10 +62,17 @@ class ChargerSpotScreenState extends ConsumerState<ChargerSpotScreen> {
     );
   }
 
-  void _onMapTap() {
+  void _onMapTapDown() {
     if (!showCard) return;
     setState(() {
       showCard = false;
+    });
+  }
+
+  void _onCardTapDown() {
+    if (showCard) return;
+    setState(() {
+      showCard = true;
     });
   }
 }

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/charger_spots_screen.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/charger_spots_screen.dart
@@ -2,15 +2,11 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_challenge1_yuta_ktd/constant/decolation_style.dart';
-import 'package:flutter_challenge1_yuta_ktd/datastore/charger_spots_datastore_provider.dart';
-import 'package:flutter_challenge1_yuta_ktd/provider/charger_spots_async_provider.dart';
+import 'package:flutter_challenge1_yuta_ktd/view/charger_spots/component/card/card_list.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
-import '../../core/location/location_provider.dart';
-import 'component/card/charger_spots_info_card.dart';
 import 'component/map/charger_map.dart';
 import 'component/map/current_location_button.dart';
 
@@ -34,7 +30,6 @@ class ChargerSpotScreenState extends ConsumerState<ChargerSpotScreen> {
   @override
   Widget build(BuildContext context) {
     // TODO: statusでngの時にダイアログ出す
-    final asyncChargerSpots = ref.watch(chargerSpotsAsyncProvider);
     return Scaffold(
       body: Stack(
         children: [
@@ -42,8 +37,6 @@ class ChargerSpotScreenState extends ConsumerState<ChargerSpotScreen> {
             onTap: _onMapTap,
             position: position,
             controller: controller,
-
-            // onMapCreated: _onMapCreated,
           ),
           AnimatedPositioned(
             duration: showCardDuration,
@@ -71,23 +64,7 @@ class ChargerSpotScreenState extends ConsumerState<ChargerSpotScreen> {
                     showCard = true;
                   });
                 },
-                child: asyncChargerSpots.when(
-                  data: (res) => ListView.builder(
-                      scrollDirection: Axis.horizontal,
-                      itemCount: res.chargerSpots.length,
-                      itemBuilder: (_, index) {
-                        final data = res.chargerSpots[index];
-                        return ChargerSpotsInfoCard(chargerSpot: data);
-                      }),
-                  error: (error, _) {
-                    // ScaffoldMessenger.of(context).showSnackBar(
-                    //   SnackBar(content: Text(error.toString())),
-                    // );
-                    return _errorLoading(const Text('通信エラーです'));
-                  },
-                  loading: () =>
-                      _errorLoading(const CircularProgressIndicator()),
-                ),
+                child: const CardList(),
               ),
             ),
           ),
@@ -101,12 +78,5 @@ class ChargerSpotScreenState extends ConsumerState<ChargerSpotScreen> {
     setState(() {
       showCard = false;
     });
-  }
-
-  Widget _errorLoading(Widget child) {
-    return Align(
-      alignment: Alignment.topCenter,
-      child: child,
-    );
   }
 }

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/charger_spots_screen.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/charger_spots_screen.dart
@@ -58,7 +58,7 @@ class ChargerSpotScreenState extends ConsumerState<ChargerSpotScreen> {
             child: SizedBox(
               height: 272.0,
               child: GestureDetector(
-                onTap: () {
+                onTapDown: (_) {
                   if (showCard) return;
                   setState(() {
                     showCard = true;

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/charger_spots_screen.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/charger_spots_screen.dart
@@ -10,8 +10,6 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'component/map/charger_map.dart';
 import 'component/map/current_location_button.dart';
 
-// TODO: GoogleMapを呼び出したいフェーズに移ったら削除
-
 class ChargerSpotScreen extends ConsumerStatefulWidget {
   const ChargerSpotScreen({Key? key}) : super(key: key);
 

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_list.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_list.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_challenge1_yuta_ktd/provider/map_controller_completer_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:openapi/model/response.dart' as charger_spot_res;
 
 import '../../../../provider/charger_spots_async_provider.dart';
@@ -39,11 +43,19 @@ class CardList extends ConsumerWidget {
 
   Future<void> _onPageChanged(
       int value, charger_spot_res.Response res, WidgetRef ref) async {
-    final asyncChargerSpotsNotifire =
-        ref.read(chargerSpotsAsyncProvider.notifier);
-    // カードのUUIDを元に検索
-    await asyncChargerSpotsNotifire.serchChargerSpots(
-        uuid: res.chargerSpots[value].uuid);
+    final Completer<GoogleMapController> mapControllerCompleter =
+        ref.watch(mapControllerCompleterProvider);
+    final mapController = await mapControllerCompleter.future;
+    final latitude = res.chargerSpots[value].latitude.toDouble();
+    final longitude = res.chargerSpots[value].longitude.toDouble();
+    await mapController.moveCamera(
+      CameraUpdate.newCameraPosition(
+        CameraPosition(
+          target: LatLng(latitude, longitude),
+          zoom: 15,
+        ),
+      ),
+    );
   }
 
   Widget _errorLoading(Widget child) {

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_list.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_list.dart
@@ -15,7 +15,8 @@ class CardList extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final asyncChargerSpots = ref.watch(chargerSpotsAsyncProvider);
-    final PageController controller = PageController();
+    // ここでカードの横幅指定
+    final PageController controller = PageController(viewportFraction: 0.9);
 
     return asyncChargerSpots.when(
       data: (res) => PageView.builder(

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_list.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_list.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openapi/model/response.dart' as charger_spot_res;
+
+import '../../../../provider/charger_spots_async_provider.dart';
+import 'charger_spots_info_card.dart';
+
+class CardList extends ConsumerWidget {
+  const CardList({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncChargerSpots = ref.watch(chargerSpotsAsyncProvider);
+    final PageController controller = PageController();
+
+    return asyncChargerSpots.when(
+      data: (res) => PageView.builder(
+        controller: controller,
+        itemCount: res.chargerSpots.length,
+        itemBuilder: (_, index) {
+          final data = res.chargerSpots[index];
+          return ChargerSpotsInfoCard(chargerSpot: data);
+        },
+        onPageChanged: (value) async {
+          await _onPageChanged(value, res, ref);
+        },
+      ),
+      error: (error, _) {
+        // ScaffoldMessenger.of(context).showSnackBar(
+        //   SnackBar(content: Text(error.toString())),
+        // );
+        return _errorLoading(const Text('通信エラーです'));
+      },
+      loading: () => _errorLoading(
+        const CircularProgressIndicator(),
+      ),
+    );
+  }
+
+  Future<void> _onPageChanged(
+      int value, charger_spot_res.Response res, WidgetRef ref) async {
+    final asyncChargerSpotsNotifire =
+        ref.read(chargerSpotsAsyncProvider.notifier);
+    // カードのUUIDを元に検索
+    await asyncChargerSpotsNotifire.serchChargerSpots(
+        uuid: res.chargerSpots[value].uuid);
+  }
+
+  Widget _errorLoading(Widget child) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: child,
+    );
+  }
+}

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_text_infos/business_hours.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_text_infos/business_hours.dart
@@ -8,13 +8,21 @@ import '../card_text.dart';
 
 /// 営業時間に関する情報を出力する
 class BusinessHours extends StatelessWidget {
-  final List<ChargerSpotServiceTime> chargerSpotServiceTimes;
+  final List<ChargerSpotServiceTime?> chargerSpotServiceTimes;
   const BusinessHours(this.chargerSpotServiceTimes, {super.key});
 
   @override
   Widget build(BuildContext context) {
-    final ChargerSpotServiceTime todayServiceTime =
-        chargerSpotServiceTimes.singleWhere((element) => element.today);
+    if (chargerSpotServiceTimes.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final ChargerSpotServiceTime? todayServiceTime = chargerSpotServiceTimes
+        .singleWhere((element) => element!.today, orElse: () => null);
+    if (todayServiceTime == null) {
+      return const SizedBox.shrink();
+    }
+
     final isBusinessDay = todayServiceTime.businessDay == BusinessDay.yes;
     final startTime = todayServiceTime.startTime;
     final endTime = todayServiceTime.endTime;

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/charger_spots_info_card.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/charger_spots_info_card.dart
@@ -19,24 +19,21 @@ class ChargerSpotsInfoCard extends ConsumerWidget {
         borderRadius: BorderRadius.circular(cardCircular),
       ),
       clipBehavior: Clip.antiAliasWithSaveLayer,
-      child: SizedBox(
-        width: 364.0,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SizedBox(
-              height: 72.0,
-              child: _images(chargerSpot.images),
-            ),
-            CardTextInfo(
-              name: chargerSpot.name,
-              latitude: chargerSpot.latitude,
-              longitude: chargerSpot.longitude,
-              chargerSpotServiceTimes: chargerSpot.chargerSpotServiceTimes,
-              chargerDevices: chargerSpot.chargerDevices,
-            ),
-          ],
-        ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            height: 72.0,
+            child: _images(chargerSpot.images),
+          ),
+          CardTextInfo(
+            name: chargerSpot.name,
+            latitude: chargerSpot.latitude,
+            longitude: chargerSpot.longitude,
+            chargerSpotServiceTimes: chargerSpot.chargerSpotServiceTimes,
+            chargerDevices: chargerSpot.chargerDevices,
+          ),
+        ],
       ),
     );
   }
@@ -52,7 +49,6 @@ class ChargerSpotsInfoCard extends ConsumerWidget {
       itemBuilder: (_, index) {
         final url = imagesUrl[index].url;
         // 最後の要素かどうかをチェック
-        // FIXME: 右側に少しだけ間隔が残ってしまっている
         bool isLast = index == imagesUrl.length - 1;
         return Container(
           width: 180.5,

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/map/charger_map.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/map/charger_map.dart
@@ -3,26 +3,16 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:openapi/models.dart';
 
 import '../../../../core/location/location_provider.dart';
 import '../../../../provider/charger_spots_async_provider.dart';
+import '../../../../provider/map_controller_completer_provider.dart';
 
 /// GoogleMap
 class ChargerMap extends ConsumerStatefulWidget {
-  final VoidCallback? onTap;
-  final Completer<GoogleMapController> controller;
-  final void Function(GoogleMapController)? onMapCreated;
-  final Position? position;
-  const ChargerMap({
-    super.key,
-    required this.controller,
-    this.onTap,
-    this.onMapCreated,
-    this.position,
-  });
+  const ChargerMap({super.key});
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => _ChargerMapState();
@@ -38,7 +28,6 @@ class _ChargerMapState extends ConsumerState<ChargerMap> {
     return locationAsyncValue.when(
       data: (location) {
         return GoogleMap(
-          onTap: (_) => widget.onTap,
           mapType: MapType.normal,
           myLocationEnabled: true,
           initialCameraPosition: CameraPosition(
@@ -73,15 +62,18 @@ class _ChargerMapState extends ConsumerState<ChargerMap> {
   }
 
   Future<void> _onMapCreated(GoogleMapController mapController) async {
-    widget.controller.complete(mapController);
-    final chargerSpotsNotifire = ref.read(chargerSpotsAsyncProvider.notifier);
+    final Completer<GoogleMapController> mapControllerCompleter =
+        ref.watch(mapControllerCompleterProvider);
+    mapControllerCompleter.complete(mapController);
+    // TODO: 504返ってくるので一旦通信止める
+    // final chargerSpotsNotifire = ref.read(chargerSpotsAsyncProvider.notifier);
     // FIXME: 遅延を入れないと現在表示領域が地図全体(LatLng(-90.0, -180.0)みたいに)なってしまう
     // もっとロバストな方法を考える
-    await Future.delayed(Duration(seconds: 1));
-    final LatLngBounds visibleRegion = await mapController.getVisibleRegion();
-    inspect(visibleRegion);
-    final LatLng southwest = visibleRegion.southwest;
-    final LatLng northeast = visibleRegion.northeast;
+    // await Future.delayed(const Duration(seconds: 1));
+    // final LatLngBounds visibleRegion = await mapController.getVisibleRegion();
+    // inspect(visibleRegion);
+    // final LatLng southwest = visibleRegion.southwest;
+    // final LatLng northeast = visibleRegion.northeast;
     // await chargerSpotsNotifire.serchChargerSpots(
     //   swLat: southwest.latitude.toString(),
     //   swLng: southwest.longitude.toString(),

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/map/current_location_button.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/map/current_location_button.dart
@@ -7,16 +7,19 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import '../../../../constant/decolation_style.dart';
 import '../../../../core/location/location_provider.dart';
 import '../../../../provider/charger_spots_async_provider.dart';
+import '../../../../provider/map_controller_completer_provider.dart';
 
-class CurrentLocationButton extends ConsumerWidget {
-  final Completer<GoogleMapController> controller;
-  const CurrentLocationButton({
-    super.key,
-    required this.controller,
-  });
+class CurrentLocationButton extends ConsumerStatefulWidget {
+  const CurrentLocationButton({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _CurrentLocationButtonState();
+}
+
+class _CurrentLocationButtonState extends ConsumerState<CurrentLocationButton> {
+  @override
+  Widget build(BuildContext context) {
     return FloatingActionButton(
       onPressed: () => _moveCamera(ref),
       backgroundColor: textColor,
@@ -27,7 +30,9 @@ class CurrentLocationButton extends ConsumerWidget {
   // 位置データを取得し、カメラを移動させる
   Future<void> _moveCamera(WidgetRef ref) async {
     final position = await ref.refresh(locationProvider.future);
-    final mapController = await controller.future;
+    final Completer<GoogleMapController> mapControllerCompleter =
+        ref.watch(mapControllerCompleterProvider);
+    final mapController = await mapControllerCompleter.future;
     final latitude = position?.latitude;
     final longitude = position?.longitude;
     if (latitude == null || longitude == null) {


### PR DESCRIPTION
## やったこと
- 一覧カードをコンポーネント化
- カードをPageViewにすることで、Tapではなく表示で現在地表示を実現したました
- カードの横幅をPageVirwController側で指定
- カードのせり出しをonTapDownイベントで制御

## やってないこと
- API疎通をしての確認（モックデータを作って確認）

<img src="https://github.com/Yuta-KTD/flutter-challenge/assets/61367978/93909585-9adb-4986-b5ca-4a1a5a744891" width=350 />