### PR TITLE
🐛 : カード内のレイアウト修正

### DIFF
--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_text.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_text.dart
@@ -18,6 +18,7 @@ class CardText extends StatelessWidget {
           fontWeight: FontWeight.normal,
           color: color ?? textColor,
         ),
+        strutStyle: const StrutStyle(height: 1.4, fontSize: 14.0),
       ),
     );
   }

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_text_info.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_text_info.dart
@@ -28,14 +28,13 @@ class CardTextInfo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
-      width: 365.0,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _cardTitle(name),
-          const SizedBox(height: 8.0),
+          const SizedBox(height: 10.0),
           AvailableCharger(chargerDevices),
           heightBox12,
           ChargerPower(chargerDevices),
@@ -54,7 +53,7 @@ class CardTextInfo extends StatelessWidget {
 
   Widget _cardTitle(String name) {
     return SizedBox(
-      height: 25.0,
+      height: 23.0,
       child: Text(
         name,
         style: const TextStyle(

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_text_infos/available_charger.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_text_infos/available_charger.dart
@@ -27,23 +27,26 @@ class AvailableCharger extends StatelessWidget {
           child: const CardText('利用可能'),
         ),
         RichText(
-            text: TextSpan(
-          style: const TextStyle(
-            fontSize: 14.0,
-            color: textColor,
-          ),
-          children: [
-            TextSpan(
-              text: availableDevices.toString(),
-              style: TextStyle(
-                fontSize: 14.0,
-                color: availableDevices == 0 ? noChargerColor : availableColor,
-              ),
+          strutStyle: const StrutStyle(height: 1.35, fontSize: 14.0),
+          text: TextSpan(
+            style: const TextStyle(
+              fontSize: 14.0,
+              color: textColor,
             ),
-            const TextSpan(text: '/'),
-            TextSpan(text: allDevices.toString()),
-          ],
-        )),
+            children: [
+              TextSpan(
+                text: availableDevices.toString(),
+                style: TextStyle(
+                  fontSize: 14.0,
+                  color:
+                      availableDevices == 0 ? noChargerColor : availableColor,
+                ),
+              ),
+              const TextSpan(text: '/'),
+              TextSpan(text: allDevices.toString()),
+            ],
+          ),
+        ),
       ],
     );
   }

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_text_infos/business_hours.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_text_infos/business_hours.dart
@@ -14,7 +14,20 @@ class BusinessHours extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (chargerSpotServiceTimes.isEmpty) {
-      return const SizedBox.shrink();
+      return SizedBox(
+        height: 19.0,
+        child: Row(
+          children: [
+            CardTextInfoTitle(
+              // unKnownの場合も営業時間外とする
+              title: '営業中',
+              color: availableColor,
+              image: Assets.watchLator.image(width: 16.0, height: 16.0),
+            ),
+          ],
+        ),
+      );
+      ;
     }
 
     final ChargerSpotServiceTime? todayServiceTime = chargerSpotServiceTimes


### PR DESCRIPTION
- 充電出力のテキストの高さが揃ってなかったので修正
- 利用可能時間がタイトルと内容で高さが揃ってなかったので修正
- strutTextを使って英数字と日本語のテキストの高さを調整([参考](https://zenn.dev/shima999ba/articles/a1241cc8a06930#%E3%81%9D%E3%81%AE3-strutstyle%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A6%E8%AA%BF%E6%95%B4%E3%82%92%E3%81%99%E3%82%8B))
- カード内間隔でずれている部分を調整