### PR TITLE
🔧 : ref.readはbuildメソッドで呼ばず、ref.watchは非同期処理イベント内で呼ばない

### DIFF
--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_list.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/card_list.dart
@@ -20,7 +20,7 @@ class CardList extends ConsumerWidget {
     final PageController controller = ref.watch(pageControllerProvider);
     final Completer<GoogleMapController> mapControllerCompleter =
         ref.watch(mapControllerCompleterProvider);
-    final showCardNotifire = ref.read(showCardProvider.notifier);
+    final showCardNotifire = ref.watch(showCardProvider.notifier);
 
     return asyncChargerSpots.when(
       data: (res) => PageView.builder(

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/map/charger_map.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/map/charger_map.dart
@@ -28,8 +28,8 @@ class _ChargerMapState extends ConsumerState<ChargerMap> {
     final pageController = ref.watch(pageControllerProvider);
     final iconCardConnection = ref.watch(iconCardConnectProvider);
     final Completer<GoogleMapController> mapControllerCompleter =
-        ref.read(mapControllerCompleterProvider);
-    final showCardNotifire = ref.read(showCardProvider.notifier);
+        ref.watch(mapControllerCompleterProvider);
+    final showCardNotifire = ref.watch(showCardProvider.notifier);
     final markerManager = MarkerManager(
       pageController: pageController,
       iconCardConnection: iconCardConnection,
@@ -51,7 +51,8 @@ class _ChargerMapState extends ConsumerState<ChargerMap> {
             ),
             zoom: 15,
           ),
-          onMapCreated: _onMapCreated,
+          onMapCreated: (mapController) =>
+              _onMapCreated(mapController, mapControllerCompleter),
           myLocationButtonEnabled: false,
           onTap: (_) => showCardNotifire.state = false,
           markers: chargerSpotsProvider.when(
@@ -78,10 +79,8 @@ class _ChargerMapState extends ConsumerState<ChargerMap> {
     );
   }
 
-  Future<void> _onMapCreated(GoogleMapController mapController) async {
-    final Completer<GoogleMapController> mapControllerCompleter =
-        ref.watch(mapControllerCompleterProvider);
-
+  Future<void> _onMapCreated(GoogleMapController mapController,
+      Completer<GoogleMapController> mapControllerCompleter) async {
     mapControllerCompleter.complete(mapController);
     final chargerSpotsNotifire = ref.read(chargerSpotsAsyncProvider.notifier);
     // FIXME: 遅延を入れないと現在表示領域が地図全体(LatLng(-90.0, -180.0))なってしまう


### PR DESCRIPTION
- 公式の注意を元にref.watch, ref.readの記述を変更
  - [ref.watch](https://docs-v2.riverpod.dev/docs/concepts/reading#using-refwatch-to-observe-a-provider:~:text=the%20new%20value.-,CAUTION,-The%20watch%20method)
  - [ref.read](https://docs-v2.riverpod.dev/docs/concepts/reading#dont-use-refread-inside-the-build-method)