### PR TITLE
🚸  画面を縦向きに固定

### DIFF
--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/main.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_challenge1_yuta_ktd/app.dart';
 import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,5 +7,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 Future main() async {
   WidgetsFlutterBinding.ensureInitialized(); // Required by FlutterConfig
   await FlutterConfig.loadEnvVariables();
+  //　マップアプリを使うシチュエーションを考えて画面の向きは縦固定にする
+  SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+  ]);
   runApp(const ProviderScope(child: MyApp()));
 }


### PR DESCRIPTION
- マップアプリを使うケースとして、縦画面が多いと考えたので縦画面固定にしました
- 裏テーマとして、横向きの動作検証が不十分なため、余計な不具合を出したくないという背景もあります。