### PR TITLE
🐛  : 初回スポット検索時と、取得件数0件を区別できていなかった不具合修正

### DIFF
--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/map/charger_map.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/map/charger_map.dart
@@ -28,6 +28,7 @@ class _ChargerMapState extends ConsumerState<ChargerMap> {
     final markersAsyncValue = ref.watch(mapMarkerAsyncProvider);
     final locationAsyncValue = ref.watch(locationProvider);
     final chargerSpotAsyncValue = ref.watch(chargerSpotsAsyncProvider);
+
     return locationAsyncValue.when(
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, _) {
@@ -85,18 +86,5 @@ class _ChargerMapState extends ConsumerState<ChargerMap> {
   Future<void> _onMapCreated(GoogleMapController mapController,
       Completer<GoogleMapController> mapControllerCompleter) async {
     mapControllerCompleter.complete(mapController);
-    final chargerSpotsNotifire = ref.read(chargerSpotsAsyncProvider.notifier);
-    // FIXME: 遅延を入れないと現在表示領域が地図全体(LatLng(-90.0, -180.0))なってしまう
-    // もっとロバストな方法を考える
-    await Future.delayed(const Duration(seconds: 1));
-    final LatLngBounds visibleRegion = await mapController.getVisibleRegion();
-    final LatLng southwest = visibleRegion.southwest;
-    final LatLng northeast = visibleRegion.northeast;
-    await chargerSpotsNotifire.serchChargerSpots(
-      swLat: southwest.latitude.toString(),
-      swLng: southwest.longitude.toString(),
-      neLat: northeast.latitude.toString(),
-      neLng: northeast.longitude.toString(),
-    );
   }
 }

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/map/current_location_button.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/map/current_location_button.dart
@@ -30,7 +30,7 @@ class _CurrentLocationButtonState extends ConsumerState<CurrentLocationButton> {
     );
   }
 
-  // 位置データを取得し、カメラを移動させる
+  // 位置データを取得し、カメラを移動させると同時に、検索を行う
   Future<void> _moveCamera(WidgetRef ref) async {
     final position = await ref.refresh(locationProvider.future);
     final Completer<GoogleMapController> mapControllerCompleter =


### PR DESCRIPTION
## 不具合内容
初回表示で必ず「検索結果なし」の内容が出力されてしまっていた

## 原因
初回スポット検索時（AsyncNotifireの`build()`メソッド内）で、スポット取得件数0件のレスポンスを擬似的に返してしまっていたことが原因で、初期表示時データと取得件数0件を区別できていなかった。

## 対処
初回表示時にもスポット検索を行うようにする