### PR TITLE
🐛 画像が一枚しかない時の表示を修正

### DIFF
--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/charger_spots_info_card.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/component/card/charger_spots_info_card.dart
@@ -39,10 +39,19 @@ class ChargerSpotsInfoCard extends ConsumerWidget {
     );
   }
 
-  /// カード上部の画像
+  /// カード上部の画像、枚数によって表示方法を変える
   Widget _images(List<ChargerSpotImage> imagesUrl) {
     if (imagesUrl.isEmpty) {
       return Assets.image.cardWhenNoImages.image(fit: BoxFit.cover);
+    }
+    if (imagesUrl.length == 1) {
+      return SizedBox(
+        width: double.infinity,
+        child: Image.network(
+          imagesUrl[0].url,
+          fit: BoxFit.cover,
+        ),
+      );
     }
     return ListView.builder(
       scrollDirection: Axis.horizontal,


### PR DESCRIPTION
- チャージャー情報で、画像が一枚しかない場合に画像がカードいっぱいに表示されない不具合を修正しました。

<img src="https://github.com/Yuta-KTD/flutter-challenge/assets/61367978/5ca1e103-4c20-4490-bbd4-367eed210929" width=350 />