### PR TITLE
🐛 エラーやローディングの時の表示コンテンツがカードがせり上がった状態と同じ位置に出てしまう不具合修正

### DIFF
--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/provider/charger_spots_async_provider.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/provider/charger_spots_async_provider.dart
@@ -9,6 +9,7 @@ import '../model/charger_spots_request.dart';
 import '../repository/charger_spots_repository_provider.dart';
 import 'map_controller_completer_provider.dart';
 import 'page_controller_provider.dart';
+import 'show_card_provider.dart';
 
 class ChargerSpotsAsyncNotifire
     extends AutoDisposeAsyncNotifier<charger_spot_res.Response> {
@@ -58,6 +59,9 @@ class ChargerSpotsAsyncNotifire
       uuid: uuid,
       fields: fields,
     );
+    // 検索時はカードはひっこめる
+    final showCardNotifire = ref.watch(showCardProvider.notifier);
+    showCardNotifire.state = false;
     final repository = ref.read(chargerSpotsRepositoryProvider);
     state = await AsyncValue.guard(() async {
       return await repository.fetchChargerSpots(reqestParam);

--- a/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/charger_spots_screen.dart
+++ b/Yuta-KTD/flutter_challenge1_yuta_ktd/lib/view/charger_spots/charger_spots_screen.dart
@@ -23,7 +23,6 @@ class ChargerSpotScreenState extends ConsumerState<ChargerSpotScreen> {
   @override
   Widget build(BuildContext context) {
     final showCard = ref.watch(showCardProvider);
-    // TODO: statusでngの時にダイアログ出す
     return SafeArea(
       child: Scaffold(
         body: Stack(


### PR DESCRIPTION
- 検索時にカード位置をひっこめることで、エラーやローディングの時の表示コンテンツがカードがせり上がった状態と同じ位置に出てしまう不具合を修正しました